### PR TITLE
[refactor] Fix environment-scoped resource naming

### DIFF
--- a/terraform/geomatch_app/sftp/main.tf
+++ b/terraform/geomatch_app/sftp/main.tf
@@ -14,7 +14,7 @@ locals {
 }
 
 resource "aws_security_group" "this" {
-  name   = "${var.project}-sftp-sg"
+  name   = "${var.project}-${var.environment}-sftp-sg"
   vpc_id = local.vpc_id
 
   ingress {
@@ -29,7 +29,7 @@ resource "aws_security_group" "this" {
     # SFTP tags are different because we resuse
     # resources across environments.
     Project = var.project
-    # TODO(refactor) here and eslewhere here
+    Environment = var.environment
   }
 
   lifecycle {
@@ -42,11 +42,12 @@ resource "aws_eip" "this" {
   # with our account.
   tags = {
     Project = var.project
+    Environment = var.environment
   }
 }
 
 resource "aws_cloudwatch_log_group" "sftp_server" {
-  name_prefix = "${var.project}-sftp-"
+  name_prefix = "${var.project}-${var.environment}-sftp-"
 }
 
 resource "aws_transfer_server" "this" {
@@ -71,11 +72,12 @@ resource "aws_transfer_server" "this" {
 
   tags = {
     Project = var.project
+    Environment = var.environment
   }
 }
 
 resource "aws_iam_role" "sftp_logging" {
-  name = "${var.project}-sftp-logging-role"
+  name = "${var.project}-${var.environment}-sftp-logging-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -108,6 +110,7 @@ resource "aws_iam_role" "sftp_logging" {
 
   tags = {
     Project = var.project
+    Environment = var.environment
   }
 }
 

--- a/terraform/geomatch_app/sftp/ssm_parameters.tf
+++ b/terraform/geomatch_app/sftp/ssm_parameters.tf
@@ -1,5 +1,5 @@
 locals {
-  ssm_name_prefix           = "/${var.project}"
+  ssm_name_prefix           = "/${var.project}/${var.environment}"
   ssm_name_host_private_key = "${local.ssm_name_prefix}/SFTP_HOST_PRIVATE_KEY"
   ssm_name_host_public_key  = "${local.ssm_name_prefix}/SFTP_HOST_PUBLIC_KEY"
 }

--- a/terraform/geomatch_app/sftp/ssm_parameters.tf
+++ b/terraform/geomatch_app/sftp/ssm_parameters.tf
@@ -18,7 +18,8 @@ resource "aws_ssm_parameter" "host_private_key" {
   }
 
   tags = {
-    Project = var.project
+    Project     = var.project
+    Environment = var.environment
   }
 }
 
@@ -43,7 +44,8 @@ resource "aws_ssm_parameter" "host_public_key" {
   }
 
   tags = {
-    Project = var.project
+    Project     = var.project
+    Environment = var.environment
   }
 }
 

--- a/terraform/geomatch_app/sftp_user/main.tf
+++ b/terraform/geomatch_app/sftp_user/main.tf
@@ -14,7 +14,7 @@ locals {
 }
 
 resource "aws_iam_role" "sftp_user" {
-  name = "${var.project}-${var.environment}-sftp-user-role"
+  name = "${var.project}-${var.environment}-${var.user_id}-sftp-user-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
@@ -30,7 +30,7 @@ resource "aws_iam_role" "sftp_user" {
   })
 
   inline_policy {
-    name = "${var.project}-${var.environment}-sftp-user-policy"
+    name = "${var.project}-${var.environment}-${var.user_id}-sftp-user-policy"
     policy = jsonencode({
       "Version" : "2012-10-17",
       "Statement" : [
@@ -56,6 +56,7 @@ resource "aws_iam_role" "sftp_user" {
   tags = {
     Project     = var.project
     Environment = var.environment
+    UserId      = var.user_id
   }
 }
 
@@ -69,6 +70,7 @@ resource "aws_transfer_user" "this" {
   tags = {
     Project     = var.project
     Environment = var.environment
+    UserId      = var.user_id
   }
 }
 
@@ -80,11 +82,12 @@ resource "aws_transfer_ssh_key" "this" {
 }
 
 resource "aws_s3_bucket" "this" {
-  bucket = "${var.project}-${var.environment}-sftp"
+  bucket = "${var.project}-${var.environment}-${var.user_id}-sftp"
 
   tags = {
     Project     = var.project
     Environment = var.environment
+    UserId      = var.user_id
   }
 }
 

--- a/terraform/geomatch_app/sftp_user/main.tf
+++ b/terraform/geomatch_app/sftp_user/main.tf
@@ -55,7 +55,7 @@ resource "aws_iam_role" "sftp_user" {
 
   tags = {
     Project     = var.project
-    Environment = var.environment 
+    Environment = var.environment
   }
 }
 
@@ -68,7 +68,7 @@ resource "aws_transfer_user" "this" {
 
   tags = {
     Project     = var.project
-    Environment = var.environment 
+    Environment = var.environment
   }
 }
 
@@ -84,7 +84,7 @@ resource "aws_s3_bucket" "this" {
 
   tags = {
     Project     = var.project
-    Environment = var.environment 
+    Environment = var.environment
   }
 }
 

--- a/terraform/geomatch_app/sftp_user/ssm_parameters.tf
+++ b/terraform/geomatch_app/sftp_user/ssm_parameters.tf
@@ -7,7 +7,7 @@ locals {
 resource "aws_ssm_parameter" "user_public_key" {
   name        = local.ssm_name_user_public_key
   type        = "SecureString"
-  value       = "placeholder"
+  value       = var.public_key
   description = "AWS Transfer Family only accepts PEM formatted public keys. See https://docs.aws.amazon.com/transfer/latest/userguide/key-management.html#convert-ssh2-public-key"
   overwrite   = false
 
@@ -34,7 +34,7 @@ data "aws_ssm_parameter" "user_public_key" {
 resource "aws_ssm_parameter" "sftp_username" {
   name        = local.ssm_name_username
   type        = "SecureString"
-  value       = "prod-username"
+  value       = var.username
   description = ""
   overwrite   = false
 

--- a/terraform/geomatch_app/sftp_user/ssm_parameters.tf
+++ b/terraform/geomatch_app/sftp_user/ssm_parameters.tf
@@ -1,8 +1,7 @@
 locals {
-  ssm_name_prefix                  = "/${var.project}"
-  # TODO(refactor)
-  ssm_name_user_public_key    = "${local.ssm_name_prefix}/SFTP_${upper(var.environment)}_USER_PUBLIC_KEY"
-  ssm_name_username           = "${local.ssm_name_prefix}/SFTP_${upper(var.environment)}_USERNAME"
+  ssm_name_prefix          = "/${var.project}/${var.environment}"
+  ssm_name_user_public_key = "${local.ssm_name_prefix}/SFTP_USER_PUBLIC_KEY"
+  ssm_name_username        = "${local.ssm_name_prefix}/SFTP_USERNAME"
 }
 
 resource "aws_ssm_parameter" "user_public_key" {
@@ -19,8 +18,8 @@ resource "aws_ssm_parameter" "user_public_key" {
   }
 
   tags = {
-    # TODO(refactor): Add environment
     Project = var.project
+    Environment = var.environment
   }
 }
 
@@ -45,8 +44,8 @@ resource "aws_ssm_parameter" "sftp_username" {
   }
 
   tags = {
-    # TODO(refactor): Add environment
     Project = var.project
+    Environment = var.environment
   }
 }
 

--- a/terraform/geomatch_app/sftp_user/ssm_parameters.tf
+++ b/terraform/geomatch_app/sftp_user/ssm_parameters.tf
@@ -18,8 +18,9 @@ resource "aws_ssm_parameter" "user_public_key" {
   }
 
   tags = {
-    Project = var.project
+    Project     = var.project
     Environment = var.environment
+    UserId      = var.user_id
   }
 }
 
@@ -44,8 +45,9 @@ resource "aws_ssm_parameter" "sftp_username" {
   }
 
   tags = {
-    Project = var.project
+    Project     = var.project
     Environment = var.environment
+    UserId      = var.user_id
   }
 }
 

--- a/terraform/geomatch_app/sftp_user/ssm_parameters.tf
+++ b/terraform/geomatch_app/sftp_user/ssm_parameters.tf
@@ -1,5 +1,5 @@
 locals {
-  ssm_name_prefix          = "/${var.project}/${var.environment}"
+  ssm_name_prefix          = "/${var.project}/${var.environment}/${var.user_id}"
   ssm_name_user_public_key = "${local.ssm_name_prefix}/SFTP_USER_PUBLIC_KEY"
   ssm_name_username        = "${local.ssm_name_prefix}/SFTP_USERNAME"
 }

--- a/terraform/geomatch_app/sftp_user/variables.tf
+++ b/terraform/geomatch_app/sftp_user/variables.tf
@@ -12,6 +12,18 @@ variable "user_id" {
   type = string
 }
 
+variable "username" {
+  type = string
+  # If not supplied, you must set via SSM and re-apply
+  default = "" 
+}
+
+variable "public_key" {
+  type = string
+  # If not supplied, you must set via SSM and re-apply
+  default = "" 
+}
+
 variable "aws_region" {
   type = string
 }

--- a/terraform/geomatch_app/sftp_user/variables.tf
+++ b/terraform/geomatch_app/sftp_user/variables.tf
@@ -6,6 +6,12 @@ variable "environment" {
   type = string
 }
 
+variable "user_id" {
+  # Note: This is not the username, but an easy to read identifier for the user
+  # Used for resource naming / tagging
+  type = string
+}
+
 variable "aws_region" {
   type = string
 }


### PR DESCRIPTION
#7 

This also adds userID to the resource naming (since a given environment's transfer server might have multiple users)