### PR TITLE
[fix] Need to change the prefix to not include environment

### DIFF
--- a/terraform/geomatch_app/sftp/efs_workflow.tf
+++ b/terraform/geomatch_app/sftp/efs_workflow.tf
@@ -10,7 +10,7 @@ module "sftp_efs" {
 }
 
 locals {
-  s3_bucket_prefix = "${var.project}-${var.environment}-"
+  s3_bucket_prefix = "${var.project}-"
   s3_bucket_suffix = "-sftp"
 }
 

--- a/terraform/geomatch_app/sftp_user/main.tf
+++ b/terraform/geomatch_app/sftp_user/main.tf
@@ -82,7 +82,7 @@ resource "aws_transfer_ssh_key" "this" {
 }
 
 resource "aws_s3_bucket" "this" {
-  bucket = "${var.sftp_module.s3_bucket_prefix}${var.user_id}${var.sftp_module.s3_bucket_suffix}"
+  bucket = "${var.sftp_module.s3_bucket_prefix}${var.environment}-${var.user_id}${var.sftp_module.s3_bucket_suffix}"
 
   tags = {
     Project     = var.project


### PR DESCRIPTION
Staging S3 (of course) is not in prod (which is technically the environment of the AWS transfser server)

Want to avoid deleting the staging S3 bucket again